### PR TITLE
Update kustomization.yaml

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -5,8 +5,7 @@
 
 ## Append samples you want in your CSV to this file as resources ##
 resources:
-  - sharding_v1alpha1_provshard.yaml
-  - autonomousdatabase.yaml
-  - singleinstancedatabase.yaml
-  - shardingdatabase.yaml
+  - adb/autonomousdatabase.yaml
+  - sidb/singleinstancedatabase.yaml
+  - sharding/shardingdatabase.yaml
   # +kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
Fixing the path for the samples. Without this fix, the 'make bundle' for OLM breaks.