### PR TITLE
:hammer: fix : swapped comments referencing prebuilt and xe

### DIFF
--- a/config/samples/sidb/singleinstancedatabase_secrets.yaml
+++ b/config/samples/sidb/singleinstancedatabase_secrets.yaml
@@ -16,7 +16,7 @@ stringData:
 
 ---
 
-## Oracle Database XE Admin password secret
+## Prebuilt-Database Admin password secret
 apiVersion: v1
 kind: Secret
 metadata:
@@ -29,7 +29,7 @@ stringData:
 
 ---
 
-## Prebuilt-Database Admin password secret
+## Oracle Database XE Admin password secret
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Hi,
the comments above the prebuilt and xe secrets seem to have been accidentaly swapped. This proposal is a change to make it right.

Please accept my Pull-Request 🍀