### PR TITLE
Assign a security context constraint (SCC) to the service account that grants the requested access

### DIFF
--- a/config/samples/sidb/openshift_rbac.yaml
+++ b/config/samples/sidb/openshift_rbac.yaml
@@ -12,6 +12,9 @@
    name: sidb-scc
    namespace: default
  allowPrivilegedContainer: false
+ users:
+  - system:serviceaccount:default:sidb-sa
+  - system:serviceaccount:default:oracle-database-operator
  runAsUser:
    type: MustRunAsRange
    uidRangeMin: 0


### PR DESCRIPTION
update Sample SIDB rbac to Link Users SA to SCC https://github.com/oracle/oracle-database-operator/issues/47