### PR TITLE
Align ConfigMap name in sample YAML with documentation (multiconfigjson)

### DIFF
--- a/docs/privateai/provisioning/pai_sample_publiclb_multi_replica.yaml
+++ b/docs/privateai/provisioning/pai_sample_publiclb_multi_replica.yaml
@@ -22,7 +22,7 @@ spec:
  # Configuration for Private AI
  paiConfigFile:
   # Configmap having the link for the AI Model File
-  name: privateaiconfigjson
+  name: multiconfigjson
   # Location inside the Pod to which the file containining the configmap will be mounted to
   mountLocation: /privateai/config
 


### PR DESCRIPTION
Update the ConfigMap name in the Public LB multi-replica sample YAML to match the documentation.

privateaiconfigjson → multiconfigjson

This ensures consistency with the documented setup and avoids user confusion.